### PR TITLE
Set commentstring with a ftplugin

### DIFF
--- a/ftplugin/qml.vim
+++ b/ftplugin/qml.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=//%s


### PR DESCRIPTION
Hi.

This adds a setlocal for commentstring in a filetype plugin. As far as I know is the usual way to set this kind of file type specifica variables. This one is necessary for plugins that comment/uncomment stuff, like commentary.vim.

Thanks!
