### PR TITLE
Adds indent support for multi-line comment /* */ on single line

### DIFF
--- a/indent/qml.vim
+++ b/indent/qml.vim
@@ -2,7 +2,7 @@
 " Language:     QML
 " Author:       Robert Kieffer
 " URL:
-" Last Change:  2010-03-27 (Happy Birthday, Dash!)
+" Last Change:  2017-10-27
 "
 " Improved JavaScript indent script.
 
@@ -20,10 +20,10 @@ if exists("*GetJsIndent")
   finish
 endif
 
-" Clean up a line of code by removing trailing '//' comments, and trimming
+" Clean up a line of code by removing trailing '//' and '/* */' comments, and trimming
 " whitespace
 function! Trim(line)
-  return substitute(substitute(a:line, '// .*', '', ''), '^\s*\|\s*$', '', 'g')
+  return substitute(substitute(substitute(a:line, '// .*', '', ''), '/\* .* \*/', '', ''), '^\s*\|\s*$', '', 'g')
 endfunction
 
 function! GetJsIndent()


### PR DESCRIPTION
I tend to use block commenting style as single-line EOL comments in some instances and it trashes my QML indentation structure. I've added basic handling of single-line EOL block comments (`/* */`) in-line with the way single-line comments (`//`) are handled.

If I am just following poor practice with single-line block comments and this isn't worth supporting, I understand completely.

As an example, before, I would see this:
```qml
  Button { /* move down */
  text: "\u25BC"
  Layout.preferredWidth: parent.btn_width
  height: parent.btn_height
  font.pointSize: 12
}
```

What I hoped for, and what is accomplished with this PR is:
```qml
Button { /* move down */
  text: "\u25BC"
  Layout.preferredWidth: parent.btn_width
  height: parent.btn_height
  font.pointSize: 12
}
```

In both cases, moving the single-line block comment to its own line works as expected because of the explicit handling of multi-line (block) commenting style in the current indent script:
```qml
Button {
  /* move down */
  text: "\u25BC"
  Layout.preferredWidth: parent.btn_width
  height: parent.btn_height
  font.pointSize: 12
}
```