### PR TITLE
iss#9: fixed syntax hl in ternary js expression

### DIFF
--- a/syntax/qml.vim
+++ b/syntax/qml.vim
@@ -24,7 +24,7 @@ endif
 
 syn case ignore
 
-
+syn cluster qmlExpr              contains=qmlStringD,qmlString,SqmlCharacter,qmlNumber,qmlObjectLiteralType,qmlBoolean,qmlType,qmlJsType,qmlNull,qmlGlobal,qmlFunction
 syn keyword qmlCommentTodo       TODO FIXME XXX TBD contained
 syn match   qmlLineComment       "\/\/.*" contains=@Spell,qmlCommentTodo
 syn match   qmlCommentSkip       "^[ \t]*\*\($\|[ \t]\+\)"
@@ -37,7 +37,7 @@ syn match   qmlCharacter         "'\\.'"
 syn match   qmlNumber            "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
 syn region  qmlRegexpString      start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
 syn match   qmlObjectLiteralType "[A-Za-z][_A-Za-z0-9]*\s*\({\)\@="
-syn match   qmlNonBindingColon   "?[^;]*:"
+syn region  qmlTernaryColon   start="?" end=":" contains=@qmlExpr,qmlBraces,qmlParens
 syn match   qmlBindingProperty   "\<[A-Za-z][_A-Za-z.0-9]*\s*:"
 
 syn keyword qmlConditional       if else switch
@@ -120,7 +120,6 @@ if version >= 508 || !exists("did_qml_syn_inits")
   HiLink qmlReserved          Keyword
   HiLink qmlDebug             Debug
   HiLink qmlConstant          Label
-  HiLink qmlNonBindingColon   NONE
   HiLink qmlBindingProperty   Label
   HiLink qmlDeclaration       Function
 


### PR DESCRIPTION
The changes proposed have solved the cases that I presented to escalate the issue. I'm a novice at crafting syntax files for vim so I apologize if I've made any obvious mistakes. I noticed that the first ternary expression argument was being matched by the `qmlNonBindingColon` which linked to the `NONE` highlight group. I removed this match and replaced it with a region that encloses only the first ternary expression argument (since the second is already considered part of the TOP level; not captured by the `qmlNonBindingColon`). I was a bit generous with the groups that I added to the region's `contains=` but it has resulted in correct highlighting of the obvious expression types.

Here is the "after" image for comparison with the escalation in #9:
![2017-11-10-02 46 17_1052x566_scrot](https://user-images.githubusercontent.com/9826865/32655188-75e811f2-c5c1-11e7-9646-2a070b237621.png)

