### PR TITLE
Combine multiple qmlStringD and qmlStringS.

### DIFF
--- a/syntax/qml.vim
+++ b/syntax/qml.vim
@@ -33,10 +33,8 @@ syn match   qmlLineComment       "\/\/.*" contains=@Spell,qmlCommentTodo
 syn match   qmlCommentSkip       "^[ \t]*\*\($\|[ \t]\+\)"
 syn region  qmlComment           start="/\*"  end="\*/" contains=@Spell,qmlCommentTodo fold
 syn match   qmlSpecial           "\\\d\d\d\|\\."
-syn region  qmlStringD           start=+"+  skip=+\\\\\|\\"\|\\$+  end=+"\|$+  contains=qmlSpecial,@htmlPreproc,@Spell
-syn region  qmlStringS           start=+'+  skip=+\\\\\|\\'\|\\$+  end=+'\|$+  contains=qmlSpecial,@htmlPreproc,@Spell
-syn region  qmlStringD           start=+"+  end=+"+  keepend  contains=qmlSpecial,@htmlPreproc,@Spell
-syn region  qmlStringS           start=+'+  end=+'+  keepend  contains=qmlSpecial,@htmlPreproc,@Spell
+syn region  qmlStringD           start=+"+  skip=+\\\\\|\\"\|\\$+  end=+"+  keepend  contains=qmlSpecial,@htmlPreproc,@Spell
+syn region  qmlStringS           start=+'+  skip=+\\\\\|\\'\|\\$+  end=+'+  keepend  contains=qmlSpecial,@htmlPreproc,@Spell
 
 syn match   qmlCharacter         "'\\.'"
 syn match   qmlNumber            "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"


### PR DESCRIPTION
The second set overrode the first set and in the process broke the handling for escaped quotes inside strings. This keeps the multi-line handling from the second set as well as the `skip` from the first set which allows the escaped quotes.

This example QML code shows all the features working:
```
import QtQuick 2.0

Item {
    property string singleLineDouble: "single-line"
    property string multiLineDouble: "This is the first line.
This: is the second.
And we have a third one, too."

    property string singleLineSingle: 'single-line'
    property string multiLineSingle: 'This is the first line.
This: is the second.
And we have a third one, too.'

    property string escapedDouble: "1\" an hour"
    property string escapedSingle: '2\' a day'

    property string multiLineEscapedDouble: "This is the first line.
This: is the second, with a \" quote.
And we have a third one, too."

    property string multiLineEscapedSingle: 'This is the first line.
This: is the second, with a \' quote.
And we have a third one, too.'
}
```