### PR TITLE
Highlight vector2d and vector4d types

### DIFF
--- a/syntax/qml.vim
+++ b/syntax/qml.vim
@@ -52,7 +52,7 @@ syn keyword qmlRepeat            while for do in
 syn keyword qmlBranch            break continue
 syn keyword qmlOperator          new delete instanceof typeof
 syn keyword qmlJsType            Array Boolean Date Function Number Object String RegExp
-syn keyword qmlType              action alias bool color date double enumeration font int list point real rect size string time url variant vector3d
+syn keyword qmlType              action alias bool color date double enumeration font int list point real rect size string time url variant vector2d vector3d vector4d
 syn keyword qmlStatement         return with
 syn keyword qmlBoolean           true false
 syn keyword qmlNull              null undefined


### PR DESCRIPTION
Adds support for [`vector2d`](https://doc.qt.io/qt-5/qml-vector2d.html) and [`vector4d`](https://doc.qt.io/qt-5/qml-vector4d.html).