### PR TITLE
Added support for the nullish coalescing operator

### DIFF
--- a/syntax/qml.vim
+++ b/syntax/qml.vim
@@ -27,7 +27,7 @@ endif
 
 syn case ignore
 
-syn cluster qmlExpr              contains=qmlStringD,qmlStringS,qmlStringT,SqmlCharacter,qmlNumber,qmlObjectLiteralType,qmlBoolean,qmlType,qmlJsType,qmlNull,qmlGlobal,qmlFunction,qmlArrowFunction
+syn cluster qmlExpr              contains=qmlStringD,qmlStringS,qmlStringT,SqmlCharacter,qmlNumber,qmlObjectLiteralType,qmlBoolean,qmlType,qmlJsType,qmlNull,qmlGlobal,qmlFunction,qmlArrowFunction,qmlNullishCoalescing
 syn keyword qmlCommentTodo       TODO FIXME XXX TBD contained
 syn match   qmlLineComment       "\/\/.*" contains=@Spell,qmlCommentTodo
 syn match   qmlCommentSkip       "^[ \t]*\*\($\|[ \t]\+\)"
@@ -45,6 +45,7 @@ syn region  qmlRegexpString      start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi
 syn match   qmlObjectLiteralType "[A-Za-z][_A-Za-z0-9]*\s*\({\)\@="
 syn region  qmlTernaryColon   start="?" end=":" contains=@qmlExpr,qmlBraces,qmlParens
 syn match   qmlBindingProperty   "\<[A-Za-z][_A-Za-z.0-9]*\s*:"
+syn match  qmlNullishCoalescing    "??"
 
 syn keyword qmlConditional       if else switch
 syn keyword qmlRepeat            while for do in
@@ -1061,7 +1062,7 @@ syntax keyword qmlObjectLiteralType XYSeries
 
 syntax keyword qmlObjectLiteralType YAnimator
 
-syntax keyword qmlObjectLiteralType ZoomBlur 
+syntax keyword qmlObjectLiteralType ZoomBlur
 
 " }}}
 
@@ -1122,6 +1123,7 @@ if version >= 508 || !exists("did_qml_syn_inits")
   HiLink qmlNull              Keyword
   HiLink qmlBoolean           Boolean
   HiLink qmlRegexpString      String
+  HiLink qmlNullishCoalescing Operator
 
   HiLink qmlIdentifier        Identifier
   HiLink qmlLabel             Label


### PR DESCRIPTION
Messes up the syntax and indenting when using the nullish coalescing operator. Added in [5.15](https://www.qt.io/blog/new-qml-language-features-in-qt-5.15)