### PR TITLE
Allow line comments on multi-line ternary statements.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,9 @@ have made contributions:
 
 * 14mRh4X0r
 * Alejandro Exojo
+* Furkan Üzümcü
 * Luis Gabriel Lima
+* Matthew Fry
 * miruka
 * NaKyle
 * N.Sukegawa

--- a/syntax/qml.vim
+++ b/syntax/qml.vim
@@ -43,7 +43,7 @@ syn match   qmlCharacter         "'\\.'"
 syn match   qmlNumber            "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
 syn region  qmlRegexpString      start=+/[^/*]+me=e-1 skip=+\\\\\|\\/+ end=+/[gi]\{0,2\}\s*$+ end=+/[gi]\{0,2\}\s*[;.,)\]}]+me=e-1 contains=@htmlPreproc oneline
 syn match   qmlObjectLiteralType "[A-Za-z][_A-Za-z0-9]*\s*\({\)\@="
-syn region  qmlTernaryColon   start="?" end=":" contains=@qmlExpr,qmlBraces,qmlParens
+syn region  qmlTernaryColon   start="?" end=":" contains=@qmlExpr,qmlBraces,qmlParens,qmlLineComment
 syn match   qmlBindingProperty   "\<[A-Za-z][_A-Za-z.0-9]*\s*:"
 syn match  qmlNullishCoalescing    "??"
 


### PR DESCRIPTION
Very simple change. Just noticed that my comments on multi-line ternary statements were not being highlighted consistently.

![Before](https://github.com/peterhoeg/vim-qml/assets/4825657/5f383855-2f79-44c8-84f3-44a1f7c7e829)

![After](https://github.com/peterhoeg/vim-qml/assets/4825657/def4514a-9fa8-44d1-a79f-4945c79777dc)
